### PR TITLE
Update logging on serve command

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -44,7 +44,6 @@ func CommandServe(cmd *cobra.Command, args []string) {
 	}
 
 	content, err := ReadOpenAPIFile(filePath)
-	fmt.Println(string(content))
 
 	http.Handle("/openapi/", http.StripPrefix("/openapi", swaggerui.Handler(content)))
 	log.Println("serving on :8080")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -46,6 +46,6 @@ func CommandServe(cmd *cobra.Command, args []string) {
 	content, err := ReadOpenAPIFile(filePath)
 
 	http.Handle("/openapi/", http.StripPrefix("/openapi", swaggerui.Handler(content)))
-	log.Println("serving on :8080")
+	log.Println("Serving OpenAPI Specs on http://localhost:8080/openapi")
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }


### PR DESCRIPTION
- Remove printing the file content when using serve command
- Add URL to the serve command's log